### PR TITLE
Add support for highlighting the selected tree value in the view

### DIFF
--- a/HL7Snoop/MainForm.Designer.cs
+++ b/HL7Snoop/MainForm.Designer.cs
@@ -32,8 +32,6 @@ namespace HL7Snoop
 
         private System.Windows.Forms.Label lblMessageVersion;
 
-        private System.Windows.Forms.TextBox tbMessage;
-
         private System.Windows.Forms.TextBox tbVersion;
 
         private System.Windows.Forms.Label label1;
@@ -73,10 +71,12 @@ namespace HL7Snoop
             this.colValue = ((BrightIdeasSoftware.OLVColumn)(new BrightIdeasSoftware.OLVColumn()));
             this.lblMessageType = new System.Windows.Forms.Label();
             this.lblMessageVersion = new System.Windows.Forms.Label();
-            this.tbMessage = new System.Windows.Forms.TextBox();
             this.tbVersion = new System.Windows.Forms.TextBox();
             this.label1 = new System.Windows.Forms.Label();
             this.checkBoxEmptyFields = new System.Windows.Forms.CheckBox();
+            this.rtbMessage = new System.Windows.Forms.RichTextBox();
+            this.txtVersion = new System.Windows.Forms.TextBox();
+            this.txtMessage = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.treeListView1)).BeginInit();
             this.SuspendLayout();
             // 
@@ -110,6 +110,7 @@ namespace HL7Snoop
             this.colName,
             this.colId,
             this.colValue});
+            this.treeListView1.Cursor = System.Windows.Forms.Cursors.Default;
             this.treeListView1.FullRowSelect = true;
             this.treeListView1.GridLines = true;
             this.treeListView1.Location = new System.Drawing.Point(11, 253);
@@ -120,6 +121,7 @@ namespace HL7Snoop
             this.treeListView1.UseCompatibleStateImageBehavior = false;
             this.treeListView1.View = System.Windows.Forms.View.Details;
             this.treeListView1.VirtualMode = true;
+            this.treeListView1.SelectionChanged += new System.EventHandler(this.treeListView1_SelectionChanged);
             // 
             // colName
             // 
@@ -144,39 +146,23 @@ namespace HL7Snoop
             this.lblMessageType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
             this.lblMessageType.AutoSize = true;
-            this.lblMessageType.Location = new System.Drawing.Point(11, 233);
+            this.lblMessageType.Location = new System.Drawing.Point(186, 11);
             this.lblMessageType.Name = "lblMessageType";
-            this.lblMessageType.Size = new System.Drawing.Size(0, 13);
+            this.lblMessageType.Size = new System.Drawing.Size(50, 13);
             this.lblMessageType.TabIndex = 7;
+            this.lblMessageType.Text = "Message";
             this.lblMessageType.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lblMessageVersion
             // 
-            this.lblMessageVersion.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Right)));
             this.lblMessageVersion.AutoSize = true;
-            this.lblMessageVersion.Location = new System.Drawing.Point(642, 232);
+            this.lblMessageVersion.Location = new System.Drawing.Point(21, 11);
             this.lblMessageVersion.Name = "lblMessageVersion";
             this.lblMessageVersion.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.lblMessageVersion.Size = new System.Drawing.Size(0, 13);
+            this.lblMessageVersion.Size = new System.Drawing.Size(42, 13);
             this.lblMessageVersion.TabIndex = 8;
+            this.lblMessageVersion.Text = "Version";
             this.lblMessageVersion.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
-            // 
-            // tbMessage
-            // 
-            this.tbMessage.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.tbMessage.Font = new System.Drawing.Font("Courier New", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.tbMessage.Location = new System.Drawing.Point(14, 32);
-            this.tbMessage.MaximumSize = new System.Drawing.Size(10000, 197);
-            this.tbMessage.Multiline = true;
-            this.tbMessage.Name = "tbMessage";
-            this.tbMessage.ScrollBars = System.Windows.Forms.ScrollBars.Both;
-            this.tbMessage.Size = new System.Drawing.Size(681, 197);
-            this.tbMessage.TabIndex = 9;
-            this.tbMessage.WordWrap = false;
-            this.tbMessage.TextChanged += new System.EventHandler(this.tbMessage_TextChanged);
             // 
             // tbVersion
             // 
@@ -207,15 +193,47 @@ namespace HL7Snoop
             this.checkBoxEmptyFields.Text = "Display Empty fields";
             this.checkBoxEmptyFields.UseVisualStyleBackColor = true;
             // 
+            // rtbMessage
+            // 
+            this.rtbMessage.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.rtbMessage.Font = new System.Drawing.Font("Courier New", 9.75F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.rtbMessage.HideSelection = false;
+            this.rtbMessage.Location = new System.Drawing.Point(11, 34);
+            this.rtbMessage.Name = "rtbMessage";
+            this.rtbMessage.Size = new System.Drawing.Size(685, 211);
+            this.rtbMessage.TabIndex = 13;
+            this.rtbMessage.Text = "";
+            this.rtbMessage.WordWrap = false;
+            this.rtbMessage.TextChanged += new System.EventHandler(this.rtbMessage_TextChanged);
+            // 
+            // txtVersion
+            // 
+            this.txtVersion.Location = new System.Drawing.Point(80, 8);
+            this.txtVersion.Name = "txtVersion";
+            this.txtVersion.ReadOnly = true;
+            this.txtVersion.Size = new System.Drawing.Size(47, 20);
+            this.txtVersion.TabIndex = 14;
+            // 
+            // txtMessage
+            // 
+            this.txtMessage.Location = new System.Drawing.Point(246, 5);
+            this.txtMessage.Name = "txtMessage";
+            this.txtMessage.ReadOnly = true;
+            this.txtMessage.Size = new System.Drawing.Size(74, 20);
+            this.txtMessage.TabIndex = 15;
+            // 
             // MainForm
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(709, 575);
+            this.Controls.Add(this.txtMessage);
+            this.Controls.Add(this.txtVersion);
+            this.Controls.Add(this.rtbMessage);
             this.Controls.Add(this.checkBoxEmptyFields);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.tbVersion);
-            this.Controls.Add(this.tbMessage);
             this.Controls.Add(this.lblMessageVersion);
             this.Controls.Add(this.lblMessageType);
             this.Controls.Add(this.treeListView1);
@@ -232,5 +250,8 @@ namespace HL7Snoop
         #endregion
 
         private System.Windows.Forms.CheckBox checkBoxEmptyFields;
+        private System.Windows.Forms.RichTextBox rtbMessage;
+        private System.Windows.Forms.TextBox txtVersion;
+        private System.Windows.Forms.TextBox txtMessage;
     }
 }

--- a/HL7Snoop/MainForm.Designer.cs
+++ b/HL7Snoop/MainForm.Designer.cs
@@ -83,7 +83,7 @@ namespace HL7Snoop
             // btnParse
             // 
             this.btnParse.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnParse.Location = new System.Drawing.Point(621, 3);
+            this.btnParse.Location = new System.Drawing.Point(622, 5);
             this.btnParse.Name = "btnParse";
             this.btnParse.Size = new System.Drawing.Size(75, 23);
             this.btnParse.TabIndex = 0;
@@ -146,11 +146,11 @@ namespace HL7Snoop
             this.lblMessageType.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
             | System.Windows.Forms.AnchorStyles.Left)));
             this.lblMessageType.AutoSize = true;
-            this.lblMessageType.Location = new System.Drawing.Point(186, 11);
+            this.lblMessageType.Location = new System.Drawing.Point(169, 11);
             this.lblMessageType.Name = "lblMessageType";
-            this.lblMessageType.Size = new System.Drawing.Size(50, 13);
+            this.lblMessageType.Size = new System.Drawing.Size(80, 13);
             this.lblMessageType.TabIndex = 7;
-            this.lblMessageType.Text = "Message";
+            this.lblMessageType.Text = "Message Type:";
             this.lblMessageType.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
             // 
             // lblMessageVersion
@@ -159,15 +159,15 @@ namespace HL7Snoop
             this.lblMessageVersion.Location = new System.Drawing.Point(21, 11);
             this.lblMessageVersion.Name = "lblMessageVersion";
             this.lblMessageVersion.RightToLeft = System.Windows.Forms.RightToLeft.No;
-            this.lblMessageVersion.Size = new System.Drawing.Size(42, 13);
+            this.lblMessageVersion.Size = new System.Drawing.Size(92, 13);
             this.lblMessageVersion.TabIndex = 8;
-            this.lblMessageVersion.Text = "Version";
+            this.lblMessageVersion.Text = "Detected Version:";
             this.lblMessageVersion.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             // 
             // tbVersion
             // 
             this.tbVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.tbVersion.Location = new System.Drawing.Point(515, 5);
+            this.tbVersion.Location = new System.Drawing.Point(515, 8);
             this.tbVersion.Name = "tbVersion";
             this.tbVersion.Size = new System.Drawing.Size(100, 20);
             this.tbVersion.TabIndex = 10;
@@ -176,7 +176,7 @@ namespace HL7Snoop
             // 
             this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(466, 8);
+            this.label1.Location = new System.Drawing.Point(466, 11);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(45, 13);
             this.label1.TabIndex = 11;
@@ -186,7 +186,7 @@ namespace HL7Snoop
             // 
             this.checkBoxEmptyFields.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.checkBoxEmptyFields.AutoSize = true;
-            this.checkBoxEmptyFields.Location = new System.Drawing.Point(342, 7);
+            this.checkBoxEmptyFields.Location = new System.Drawing.Point(341, 10);
             this.checkBoxEmptyFields.Name = "checkBoxEmptyFields";
             this.checkBoxEmptyFields.Size = new System.Drawing.Size(119, 17);
             this.checkBoxEmptyFields.TabIndex = 12;
@@ -205,11 +205,10 @@ namespace HL7Snoop
             this.rtbMessage.TabIndex = 13;
             this.rtbMessage.Text = "";
             this.rtbMessage.WordWrap = false;
-            this.rtbMessage.TextChanged += new System.EventHandler(this.rtbMessage_TextChanged);
             // 
             // txtVersion
             // 
-            this.txtVersion.Location = new System.Drawing.Point(80, 8);
+            this.txtVersion.Location = new System.Drawing.Point(116, 8);
             this.txtVersion.Name = "txtVersion";
             this.txtVersion.ReadOnly = true;
             this.txtVersion.Size = new System.Drawing.Size(47, 20);
@@ -217,7 +216,7 @@ namespace HL7Snoop
             // 
             // txtMessage
             // 
-            this.txtMessage.Location = new System.Drawing.Point(246, 5);
+            this.txtMessage.Location = new System.Drawing.Point(252, 7);
             this.txtMessage.Name = "txtMessage";
             this.txtMessage.ReadOnly = true;
             this.txtMessage.Size = new System.Drawing.Size(74, 20);

--- a/HL7Snoop/MainForm.cs
+++ b/HL7Snoop/MainForm.cs
@@ -6,6 +6,7 @@
 
 namespace HL7Snoop
 {
+    using BrightIdeasSoftware;
     using NHapi.Base.Model;
     using NHapi.Base.Parser;
     using System;
@@ -40,7 +41,7 @@ namespace HL7Snoop
         {
             try
             {
-                string hl7 = this.tbMessage.Text;
+                string hl7 = this.rtbMessage.Text;
 
                 PipeParser parser = new PipeParser();
                 IMessage hl7Message;
@@ -55,8 +56,8 @@ namespace HL7Snoop
 
                 if (hl7Message != null)
                 {
-                    this.lblMessageType.Text = hl7Message.GetStructureName();
-                    this.lblMessageVersion.Text = hl7Message.Version;
+                    this.txtMessage.Text = hl7Message.GetStructureName();
+                    this.txtVersion.Text = hl7Message.Version;
 
                     FieldGroup messageGroup = new FieldGroup() { Name = hl7Message.GetStructureName() };
                     this.ProcessStructureGroup((AbstractGroup)hl7Message, messageGroup);
@@ -256,22 +257,49 @@ namespace HL7Snoop
             };
         }
 
-        private void tbMessage_TextChanged(object sender, EventArgs e)
-        {
-            this.tbMessage.Text = this.CorrectLineFeeds(this.tbMessage.Text);
-        }
-
         private string CorrectLineFeeds(string message)
         {
-            if (Regex.IsMatch(message, "([^\r])\n"))
+            string result = message;
+            if (Regex.IsMatch(result, "([^\r])\n"))
             {
-                return Regex.Replace(message, "([^\r])\n", "$1\r\n");
+                result = Regex.Replace(result, "([^\r])\n", "$1" + System.Environment.NewLine);
             }
-            if (Regex.IsMatch(message, "\r([^\n])"))
+            if (Regex.IsMatch(result, "\r([^\n])"))
             {
-                return Regex.Replace(message, "\r([^\n])", "\r\n$1");
+                result = Regex.Replace(result, "\r([^\n])", "\r\n$1");
             }
-            return message;
+            return result;
+        }
+
+        private void treeListView1_SelectionChanged(object sender, EventArgs e)
+        {
+            var treeView = sender as TreeListView;
+            if (treeView.SelectedItem != null)
+            {
+                var searchText = ((Field)treeView.SelectedItem.RowObject).Value;
+
+                rtbMessage.SelectionStart = 0;
+                rtbMessage.SelectionLength = rtbMessage.Text.Length;
+                rtbMessage.SelectionBackColor = System.Drawing.Color.White;
+
+                if (!String.IsNullOrEmpty(searchText))
+                {
+                    var matches = Regex.Matches(rtbMessage.Text, Regex.Escape(searchText));
+
+                    foreach (Match match in matches)
+                    {
+                        rtbMessage.SelectionStart = match.Index;
+                        rtbMessage.SelectionLength = match.Length;
+                        rtbMessage.SelectionBackColor = System.Drawing.Color.Yellow;
+                    }
+                }
+            }
+        }
+
+        private void rtbMessage_TextChanged(object sender, EventArgs e)
+        {
+            //this.rtbMessage.Text = this.CorrectLineFeeds(this.rtbMessage.Text);
+            this.rtbMessage.Text = this.rtbMessage.Text.Replace(@"\n", System.Environment.NewLine);
         }
     }
 }

--- a/HL7Snoop/MainForm.cs
+++ b/HL7Snoop/MainForm.cs
@@ -41,7 +41,7 @@ namespace HL7Snoop
         {
             try
             {
-                string hl7 = this.rtbMessage.Text;
+                string hl7 = CorrectLineFeeds(this.rtbMessage.Text);
 
                 PipeParser parser = new PipeParser();
                 IMessage hl7Message;
@@ -259,16 +259,15 @@ namespace HL7Snoop
 
         private string CorrectLineFeeds(string message)
         {
-            string result = message;
-            if (Regex.IsMatch(result, "([^\r])\n"))
+            if (Regex.IsMatch(message, "([^\r])\n"))
             {
-                result = Regex.Replace(result, "([^\r])\n", "$1" + System.Environment.NewLine);
+                return Regex.Replace(message, "([^\r])\n", "$1\r\n");
             }
-            if (Regex.IsMatch(result, "\r([^\n])"))
+            if (Regex.IsMatch(message, "\r([^\n])"))
             {
-                result = Regex.Replace(result, "\r([^\n])", "\r\n$1");
+                return Regex.Replace(message, "\r([^\n])", "\r\n$1");
             }
-            return result;
+            return message;
         }
 
         private void treeListView1_SelectionChanged(object sender, EventArgs e)
@@ -293,13 +292,8 @@ namespace HL7Snoop
                         rtbMessage.SelectionBackColor = System.Drawing.Color.Yellow;
                     }
                 }
+                rtbMessage.SelectionLength = 0;
             }
-        }
-
-        private void rtbMessage_TextChanged(object sender, EventArgs e)
-        {
-            //this.rtbMessage.Text = this.CorrectLineFeeds(this.rtbMessage.Text);
-            this.rtbMessage.Text = this.rtbMessage.Text.Replace(@"\n", System.Environment.NewLine);
         }
     }
 }

--- a/HL7Snoop/MainForm.resx
+++ b/HL7Snoop/MainForm.resx
@@ -120,9 +120,6 @@
   <metadata name="headerFormatStyle1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="treeListView1.Locked" type="System.Boolean, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>True</value>
-  </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
     <value>40</value>
   </metadata>


### PR DESCRIPTION
I also re-jiggered the version/type detection to be visible in the GUI

This isn't smart enough to highlight only the selected segment/value, it does a simple regex search to highlight all occurrences.  Not ideal, but this is better than no highlighting at all.